### PR TITLE
[Feat] Like API 구현

### DIFF
--- a/src/main/java/wavelog/wavelog/domain/diary/api/DiaryController.java
+++ b/src/main/java/wavelog/wavelog/domain/diary/api/DiaryController.java
@@ -18,19 +18,6 @@ import javax.swing.text.View;
 @RestController
 @RequestMapping("/api/diaries")
 @RequiredArgsConstructor
-//@PostMapping("/register")
-//public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest request) {
-//    SignUpResponse response = memberService.signUp(request);
-//    return ResponseEntity
-//            .status(HttpStatus.CREATED)  // 201 Created
-//            .body(response);
-//}
-//
-//@PostMapping("/login")
-//public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
-//    LoginResponse response = memberService.login(request);
-//    return ResponseEntity.ok(response);
-//}
 public class DiaryController {
     private final DiaryService diaryService;
 
@@ -55,9 +42,9 @@ public class DiaryController {
     }
 
     @DeleteMapping("/delete")
-        public ResponseEntity<DeleteResponse> delete(@RequestBody DeleteRequest request) {
-            DeleteResponse response = diaryService.delete(request);
-            return ResponseEntity.ok(response);
+    public ResponseEntity<DeleteResponse> delete(@RequestBody DeleteRequest request) {
+        DeleteResponse response = diaryService.delete(request);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/wavelog/wavelog/domain/diary/application/DiaryServiceImpl.java
+++ b/src/main/java/wavelog/wavelog/domain/diary/application/DiaryServiceImpl.java
@@ -34,7 +34,7 @@ public class DiaryServiceImpl implements DiaryService{
                 .viewCount(0)
                 .member(member)
                 .build();
-        diary = diaryRepository.save(diary);
+        diaryRepository.save(diary);
         // DTO 반환
         return CreateResponse.builder()
                 .id(diary.getId())
@@ -71,7 +71,7 @@ public class DiaryServiceImpl implements DiaryService{
                 request.getContent(),
                 request.getCategory()
         );
-        diary = diaryRepository.save(diary);
+        diaryRepository.save(diary);
         // DTO 반환
         return UpdateResponse.builder()
                 .id(diary.getId())

--- a/src/main/java/wavelog/wavelog/domain/diary/domain/entity/Diary.java
+++ b/src/main/java/wavelog/wavelog/domain/diary/domain/entity/Diary.java
@@ -34,10 +34,10 @@ public class Diary extends BaseEntity {
     private String content;
 
     @Column(name = "like_count")
-    private Integer likeCount;
+    private Integer likeCount = 0;
 
     @Column(name = "view_count")
-    private Integer viewCount;
+    private Integer viewCount = 0;
 
     @Column
     private String category;
@@ -83,6 +83,16 @@ public class Diary extends BaseEntity {
         this.category = category;
 //        if(hashtags != null)
 //            this.hashtags = new ArrayList<>(hashtags);
+    }
+    // 좋아요 수 증가 감소 메서드
+    public void addLikeCount()
+    {
+        this.likeCount++;
+    }
+
+    public void deleteLikeCount() {
+        if(this.likeCount > 0)
+            this.likeCount--;
     }
 
 }

--- a/src/main/java/wavelog/wavelog/domain/like/api/LikeController.java
+++ b/src/main/java/wavelog/wavelog/domain/like/api/LikeController.java
@@ -1,0 +1,36 @@
+package wavelog.wavelog.domain.like.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import wavelog.wavelog.domain.like.application.LikeService;
+import wavelog.wavelog.domain.like.dto.AddRequest;
+import wavelog.wavelog.domain.like.dto.AddResponse;
+import wavelog.wavelog.domain.like.dto.DeleteRequest;
+import wavelog.wavelog.domain.like.dto.DeleteResponse;
+import wavelog.wavelog.global.security.CustomUserDetails;
+
+@RestController
+@RequestMapping("/api/likes")
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/add")
+    public ResponseEntity<AddResponse> add(@RequestBody AddRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getId();
+        AddResponse response = likeService.add(request, memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<DeleteResponse> delete(@RequestBody DeleteRequest request) {
+        DeleteResponse response = likeService.delete(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/wavelog/wavelog/domain/like/application/LikeService.java
+++ b/src/main/java/wavelog/wavelog/domain/like/application/LikeService.java
@@ -1,0 +1,12 @@
+package wavelog.wavelog.domain.like.application;
+
+import wavelog.wavelog.domain.like.dto.AddRequest;
+import wavelog.wavelog.domain.like.dto.AddResponse;
+import wavelog.wavelog.domain.like.dto.DeleteRequest;
+import wavelog.wavelog.domain.like.dto.DeleteResponse;
+
+public interface LikeService {
+    AddResponse add(AddRequest request, Long memberId);
+
+    DeleteResponse delete(DeleteRequest request);
+}

--- a/src/main/java/wavelog/wavelog/domain/like/application/LikeServiceImpl.java
+++ b/src/main/java/wavelog/wavelog/domain/like/application/LikeServiceImpl.java
@@ -1,0 +1,71 @@
+package wavelog.wavelog.domain.like.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import wavelog.wavelog.domain.diary.application.DiaryService;
+import wavelog.wavelog.domain.diary.domain.entity.Diary;
+import wavelog.wavelog.domain.diary.domain.repository.DiaryRepository;
+import wavelog.wavelog.domain.like.domain.entity.Like;
+import wavelog.wavelog.domain.like.domain.repository.LikeRepository;
+import wavelog.wavelog.domain.like.dto.AddRequest;
+import wavelog.wavelog.domain.like.dto.AddResponse;
+import wavelog.wavelog.domain.like.dto.DeleteRequest;
+import wavelog.wavelog.domain.like.dto.DeleteResponse;
+import wavelog.wavelog.domain.member.domain.entity.Member;
+import wavelog.wavelog.domain.member.domain.repository.MemberRepository;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeServiceImpl implements LikeService{
+    private final LikeRepository likeRepository;
+    private final DiaryRepository diaryRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public AddResponse add(AddRequest request, Long memberId) {
+        Diary diary = diaryRepository.findById(request.getDiaryId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 다이어리입니다."));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        if(likeRepository.existsByDiaryAndMember(diary, member)) {
+            throw new IllegalArgumentException("이미 좋아요를 눌렀습니다.");
+        }
+
+        Like like = new Like();
+        like.add(diary, member);
+        likeRepository.save(like);
+
+        // 좋아요 수 증가 메서드 호출 후 저장
+        diary.addLikeCount();
+        diaryRepository.save(diary);
+
+        return AddResponse.builder()
+                .diaryId(diary.getId())
+                .likeCount(diary.getLikeCount())
+                .likeCheck(true)
+                .build();
+    }
+
+
+    @Override
+    public DeleteResponse delete(DeleteRequest request) {
+        Like like = likeRepository.findById(request.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 좋아요입니다."));
+
+        Diary diary = like.getDiary();
+
+        // 좋아요 수 감소 메서드 호출 후 저장
+        diary.deleteLikeCount();
+        diaryRepository.save(diary);
+
+        return DeleteResponse.builder()
+                .message("좋아요를 삭제하였습니다.")
+                .likeCheck(false)
+                .build();
+    }
+
+}

--- a/src/main/java/wavelog/wavelog/domain/like/domain/entity/Like.java
+++ b/src/main/java/wavelog/wavelog/domain/like/domain/entity/Like.java
@@ -18,12 +18,18 @@ public class Like extends BaseEntity {
     @Column(name = "like_id")
     private Long id;
 
+    // user->member
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "diary_id")
     private Diary diary;
+
+    public void add(Diary diary, Member member) {
+        this.diary = diary;
+        this.member = member;
+    }
 
 }

--- a/src/main/java/wavelog/wavelog/domain/like/domain/repository/LikeRepository.java
+++ b/src/main/java/wavelog/wavelog/domain/like/domain/repository/LikeRepository.java
@@ -1,0 +1,13 @@
+package wavelog.wavelog.domain.like.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wavelog.wavelog.domain.diary.domain.entity.Diary;
+import wavelog.wavelog.domain.like.domain.entity.Like;
+import wavelog.wavelog.domain.member.domain.entity.Member;
+
+import javax.xml.crypto.Data;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    int countByDiary(Diary diary);
+    boolean existsByDiaryAndMember(Diary diary, Member member);
+}

--- a/src/main/java/wavelog/wavelog/domain/like/dto/AddRequest.java
+++ b/src/main/java/wavelog/wavelog/domain/like/dto/AddRequest.java
@@ -1,0 +1,11 @@
+package wavelog.wavelog.domain.like.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddRequest {
+    private Long diaryId;
+}

--- a/src/main/java/wavelog/wavelog/domain/like/dto/AddResponse.java
+++ b/src/main/java/wavelog/wavelog/domain/like/dto/AddResponse.java
@@ -1,0 +1,12 @@
+package wavelog.wavelog.domain.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddResponse {
+    private Long diaryId;
+    private Integer likeCount;
+    private boolean likeCheck;
+}

--- a/src/main/java/wavelog/wavelog/domain/like/dto/DeleteRequest.java
+++ b/src/main/java/wavelog/wavelog/domain/like/dto/DeleteRequest.java
@@ -1,0 +1,13 @@
+package wavelog.wavelog.domain.like.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DeleteRequest {
+    private Long id;
+//    private Long diaryId;
+//    private Long memberId;
+}

--- a/src/main/java/wavelog/wavelog/domain/like/dto/DeleteResponse.java
+++ b/src/main/java/wavelog/wavelog/domain/like/dto/DeleteResponse.java
@@ -1,0 +1,13 @@
+package wavelog.wavelog.domain.like.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class DeleteResponse {
+    private String message;
+    private boolean likeCheck;
+}

--- a/src/main/java/wavelog/wavelog/global/config/SecurityConfig.java
+++ b/src/main/java/wavelog/wavelog/global/config/SecurityConfig.java
@@ -68,3 +68,9 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 }
+
+//http
+//        .authorizeHttpRequests(auth -> auth
+//        .requestMatchers("/api/register").permitAll()  // 회원가입은 인증 없이 접근 허용
+//    .anyRequest().authenticated()                   // 나머지는 인증 필요
+//  )

--- a/src/main/java/wavelog/wavelog/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/wavelog/wavelog/global/jwt/JwtAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
+            chain.doFilter(req, res);
         }
-        chain.doFilter(req, res);
     }
 }

--- a/src/main/java/wavelog/wavelog/global/security/CustomUserDetails.java
+++ b/src/main/java/wavelog/wavelog/global/security/CustomUserDetails.java
@@ -1,0 +1,56 @@
+package wavelog.wavelog.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import wavelog.wavelog.domain.member.domain.entity.Member;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    // memberId와 같은 정보에 접근 가능하도록
+    private final Member member;
+
+    public CustomUserDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getWavelogId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/wavelog/wavelog/global/security/UserDetailsServiceImpl.java
+++ b/src/main/java/wavelog/wavelog/global/security/UserDetailsServiceImpl.java
@@ -24,12 +24,9 @@ public class UserDetailsServiceImpl implements UserDetailsService {
         } catch (NumberFormatException e) {
             throw new UsernameNotFoundException("Invalid user ID: " + subject, e);
         }
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new UsernameNotFoundException(memberId + " 사용자를 찾을 수 없습니다."));
-        return User.builder()
-                .username(member.getWavelogId())
-                .password(member.getPassword())
-                .authorities(Collections.emptyList())  // 권한이 없다면 빈 리스트
-                .build();
+        return new CustomUserDetails(member);
     }
 }


### PR DESCRIPTION
## ❗관련 이슈
- Like Api 구현 & global.security.CustomUserDetails 구현 feat(#10 )

## ✅ 작업 내용

- [Like Api 구현] : AddRequest, AddResponse, DeleteRequest, DeleteResponse 구현
- [Like Api 구현] : Like entity에 add 메서드 구현(setter 사용 지양을 위해)
- [Like Api 구현] : Like entity에 https://github.com/table(name = "likes") 추가 -> like는 sql 예약어와 겹침
- [Like Api 구현] : LikeServiceImpl, LikeService 구현
- [CustomUserDetails 구현] : UserDetailsServiceImpl은 내부 로직에는 충분하지만, 인증 문제에서는 UserDetails가 필요하기 때문에 해당 인터페이스를 extend하는 클래스를 구현

## 🔭ETC

- AddRequest dto의 add 메서드 인자(diaryId)와 LikeServiceImpl, LikeServiced의 add 메서드 인자(diaryId, memberId)가 일치하지 않음 -> memberId의 경우 프론트로 보낼 필요가 없고, 실제 서비스에서 인증을 위해서만 쓰이기 때문에 dto의 add에서 제외
